### PR TITLE
add travis config and readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: php
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true
+before_script:
+  - composer self-update
+  - composer update --no-interaction
+script:
+  - vendor/bin/phing

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# klever/tutor
+Easily test accessor methods on your models by providing a spec in your test case.
+
+# Installation
+```bash
+composer require --dev klever/tutor
+```
+
+# Usage
+Extend `\Klever\Tutor\AccessMethod\AbstractTestCase` and provide a spec for your model.
+
+# Example
+[`\Klever\TutorTest\AccessMethod\AbstractTestCaseIntegrationTest`](test/TutorTest/AccessMethod/AbstractTestCaseIntegrationTest.php)
+
+# Dependencies
+See [composer.json](composer.json).
+
+## Contributing
+```bash
+git clone git@github.com:tklever/tutor.git && cd tutor
+composer update && vendor/bin/phing
+```
+
+This library attempts to comply with [PSR-1][], [PSR-2][], and [PSR-4][]. If
+you notice compliance oversights, please send a patch via pull request.
+
+[PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
+[PSR-2]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md
+[PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,58 @@
+<project name="klever/tutor" default="develop" basedir=".">
+    
+    <target name="develop">
+        <phingcall target="lint"/>
+        <phingcall target="tests"/>
+    </target>
+
+    <target name="lint">
+        <phingcall target="php-lint"/>
+        <phingcall target="phpcs"/>
+    </target>
+
+    <target name="php-lint">
+        <exec command="vendor/bin/parallel-lint src test"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+
+    <target name="phpcs">
+        <exec command="vendor/bin/phpcs --standard=PSR2 --colors -p src/ test/"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+
+    <target name="phpcbf">
+        <exec command="vendor/bin/phpcbf --standard=PSR2 --colors -p src/ test/"
+              passthru="true"
+              output="/dev/stdout"
+              error="/dev/stdout"
+              checkreturn="true"/>
+    </target>
+    
+    <target name="tests">
+        <phingcall target="unit-tests"/>
+        <phingcall target="mutation-tests"/>
+    </target>
+    
+    <target name="unit-tests">
+        <exec command="vendor/bin/phpunit --coverage-text"
+            passthru="true"
+            output="/dev/stdout"
+            error="/dev/stdout"
+            checkreturn="true"/>
+    </target>
+    
+    <target name="mutation-tests">
+        <exec command="vendor/bin/humbug"
+            passthru="true"
+            output="/dev/stdout"
+            error="/dev/stdout"
+            checkreturn="true"/>
+    </target>
+    
+</project>

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,13 @@
         }
     },
     "require": {
-        "phpunit/phpunit": "^5.2"
+        "php": "^7.0|^5.5",
+        "phpunit/phpunit": "^5.0|^4.8"
     },
     "require-dev": {
+        "jakub-onderka/php-parallel-lint": "^0.9",
         "squizlabs/php_codesniffer": "^2.5",
+        "phing/phing": "^2.9",
         "humbug/humbug": "dev-master"
     }
 }

--- a/src/Tutor/AccessMethod/TestConfiguration.php
+++ b/src/Tutor/AccessMethod/TestConfiguration.php
@@ -105,7 +105,6 @@ class TestConfiguration implements TestConfigurationInterface
     {
         $this->injectionMethodTest = (bool) $injectionMethodTest;
         $this->injectionMethodTestExplicit = true;
-
     }
 
     /**

--- a/test/TutorTest/Constraint/ArrayHasKeyAndTest.php
+++ b/test/TutorTest/Constraint/ArrayHasKeyAndTest.php
@@ -20,7 +20,7 @@ class ArrayHasKeyAndTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->subConstraint = $subConstraint = $this->getMock(PHPUnit_Framework_Constraint::class);
+        $this->subConstraint = $subConstraint = $this->getMockBuilder(PHPUnit_Framework_Constraint::class)->getMock();
         $this->subConstraint = $subConstraint = new PHPUnit_Framework_Constraint_IsEqual('bar');
         $this->constraint = new ArrayHasKeyAnd('foo', $subConstraint);
     }


### PR DESCRIPTION
add phing targets to check code for syntax and style. add phing targets to run unit and mutation tests. add travis config to run linters and tests on php55, php56, php70, and hhvm. add min php version requirement (php55) based on usage of `trait` and `::class`. add readme to document how to use in another package and how to contribute.

travis config will build on each php version with the highest and lowest versions of dependencies in composer, ensuring that our dependency version ranges are accurate.

looks like you've already got a great `0.1` package here. have you thought about tagging and registering on packagist?
