### PR TITLE
identical is stronger than loose equivalency

### DIFF
--- a/src/Tutor/AccessMethod/TestTrait.php
+++ b/src/Tutor/AccessMethod/TestTrait.php
@@ -33,6 +33,7 @@ trait TestTrait
 
     /**
      * @dataProvider getClassAccessMethodTestData
+     * @param TestConfigurationInterface $config
      */
     public function testClassAccessorMethodsForName(TestConfigurationInterface $config)
     {
@@ -63,14 +64,10 @@ trait TestTrait
             Assert::assertSame($class, $setterReturn, 'Value Injection Method is not Fluent');
         }
 
-        $this->assertClassMethodReturnIsEqual(
+        $this->assertClassMethodReturnIsIdentical(
             $class,
             $accessorMethod,
             $config->getExpectedMutatedValue(),
-            0.0,
-            10,
-            false,
-            false,
             'Access Method Mutated Value Assertion Failed'
         );
     }

--- a/src/Tutor/ClassUtilitiesTrait.php
+++ b/src/Tutor/ClassUtilitiesTrait.php
@@ -5,6 +5,7 @@ namespace Klever\Tutor;
 use Klever\Tutor\Constraint\ClassMethodReturn;
 use PHPUnit_Framework_Constraint_IsEqual;
 use PHPUnit_Framework_Assert;
+use PHPUnit_Framework_Constraint_IsIdentical;
 
 trait ClassUtilitiesTrait
 {
@@ -21,6 +22,19 @@ trait ClassUtilitiesTrait
         $constraint = new ClassMethodReturn(
             $method,
             new PHPUnit_Framework_Constraint_IsEqual($value, $delta, $maxDepth, $canonicalize, $ignoreCase)
+        );
+        PHPUnit_Framework_Assert::assertThat($class, $constraint, $message);
+    }
+
+    public function assertClassMethodReturnIsIdentical(
+        $class,
+        $method,
+        $value,
+        $message = ''
+    ) {
+        $constraint = new ClassMethodReturn(
+            $method,
+            new PHPUnit_Framework_Constraint_IsIdentical($value)
         );
         PHPUnit_Framework_Assert::assertThat($class, $constraint, $message);
     }

--- a/test/TutorTest/AccessMethod/TestTraitTest.php
+++ b/test/TutorTest/AccessMethod/TestTraitTest.php
@@ -192,8 +192,8 @@ class AccessMethodTestTraitTest extends \PHPUnit_Framework_TestCase
 
         $config = new TestConfiguration('foo');
         $config->setInjectionMethodTest(true);
-        $config->setExpectedMutatedValue(new \stdClass);
-        $config->setInjectableValue(new \stdClass);
+        $config->setExpectedMutatedValue($expected = new \stdClass);
+        $config->setInjectableValue($expected);
 
         $this->trait->testClassAccessorMethodsForName($config);
     }


### PR DESCRIPTION
so, here's my idea:

seems like an identical check would be stronger than loose equivalency. i think offering both would be useful, but identical should be the default.

want both? want it configurable? which should be default?

btw, this is a breaking change.
