### PR TITLE
provide strict-equivalency check, by configuration

### DIFF
--- a/src/Tutor/AccessMethod/TestConfiguration.php
+++ b/src/Tutor/AccessMethod/TestConfiguration.php
@@ -19,6 +19,7 @@ class TestConfiguration implements TestConfigurationInterface
     private $injectableValueExplicit = false;
     private $injectionMethodFluent = false;
     private $injectorName;
+    private $strict = false;
 
     /**
      * @return mixed
@@ -166,6 +167,22 @@ class TestConfiguration implements TestConfigurationInterface
     {
         $this->expectedMutatedValue = $expectedMutatedValue;
         $this->expectedMutatedValueExplicit = true;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isStrict()
+    {
+        return $this->strict;
+    }
+
+    /**
+     * @param boolean $strict
+     */
+    public function setStrict($strict)
+    {
+        $this->strict = (boolean) $strict;
     }
 
     public static function fromArray(array $data)

--- a/src/Tutor/AccessMethod/TestTrait.php
+++ b/src/Tutor/AccessMethod/TestTrait.php
@@ -33,6 +33,7 @@ trait TestTrait
 
     /**
      * @dataProvider getClassAccessMethodTestData
+     * @param TestConfigurationInterface $config
      */
     public function testClassAccessorMethodsForName(TestConfigurationInterface $config)
     {
@@ -61,6 +62,15 @@ trait TestTrait
 
         if ($config->isInjectionMethodFluent()) {
             Assert::assertSame($class, $setterReturn, 'Value Injection Method is not Fluent');
+        }
+
+        if ($config instanceof TestConfiguration && $config->isStrict()) {
+            $this->assertClassMethodReturnIsIdentical(
+                $class,
+                $accessorMethod,
+                $config->getExpectedMutatedValue(),
+                'Access Method Mutated Value Assertion Failed'
+            );
         }
 
         $this->assertClassMethodReturnIsEqual(

--- a/src/Tutor/ClassUtilitiesTrait.php
+++ b/src/Tutor/ClassUtilitiesTrait.php
@@ -5,6 +5,7 @@ namespace Klever\Tutor;
 use Klever\Tutor\Constraint\ClassMethodReturn;
 use PHPUnit_Framework_Constraint_IsEqual;
 use PHPUnit_Framework_Assert;
+use PHPUnit_Framework_Constraint_IsIdentical;
 
 trait ClassUtilitiesTrait
 {
@@ -21,6 +22,19 @@ trait ClassUtilitiesTrait
         $constraint = new ClassMethodReturn(
             $method,
             new PHPUnit_Framework_Constraint_IsEqual($value, $delta, $maxDepth, $canonicalize, $ignoreCase)
+        );
+        PHPUnit_Framework_Assert::assertThat($class, $constraint, $message);
+    }
+
+    public function assertClassMethodReturnIsIdentical(
+        $class,
+        $method,
+        $value,
+        $message = ''
+    ) {
+        $constraint = new ClassMethodReturn(
+            $method,
+            new PHPUnit_Framework_Constraint_IsIdentical($value)
         );
         PHPUnit_Framework_Assert::assertThat($class, $constraint, $message);
     }

--- a/test/TutorTest/AccessMethod/AbstractTestCaseIntegrationTest.php
+++ b/test/TutorTest/AccessMethod/AbstractTestCaseIntegrationTest.php
@@ -43,6 +43,12 @@ class AbstractTestCaseIntegrationTest extends AbstractTestCase
                     'injectable_value' => 4,
                     'expected_value'  => true
                 ],
+                'strict' => [
+                    'default_value' => false,
+                    'injectable_value' => 4,
+                    'expected_value'  => true,
+                    'strict' => true,
+                ],
             ]
         ];
     }

--- a/test/TutorTest/AccessMethod/TestAsset/Model.php
+++ b/test/TutorTest/AccessMethod/TestAsset/Model.php
@@ -8,6 +8,7 @@ class Model
     private $bar;
     private $fiz = false;
     private $buz = true;
+    private $strict = false;
 
     /**
      * AccessMethodProvidingModel constructor.
@@ -71,5 +72,21 @@ class Model
     public function isFooANumber()
     {
         return is_numeric($this->foo);
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isStrict()
+    {
+        return $this->strict;
+    }
+
+    /**
+     * @param boolean $strict
+     */
+    public function setStrict($strict)
+    {
+        $this->strict = (boolean) $strict;
     }
 }


### PR DESCRIPTION
provide strict-equivalency check, by configuration. default equivalency unchanged.

same idea as #2 , but as a patch instead of an excuse ; )
